### PR TITLE
Python Dependency Force

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ selenium==4.22.0
 webdriver-manager==4.0.1
 aiohttp
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+anyio>=4.4.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ fuzzywuzzy
 selenium==4.22.0
 webdriver-manager==4.0.1
 aiohttp
+zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ webdriver-manager==4.0.1
 aiohttp
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
 anyio>=4.4.0 # not directly required, pinned by Snyk to avoid a vulnerability
+urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
anyio>=4.4.0 # not directly required, pinned by Snyk to avoid a vulnerability
urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability